### PR TITLE
Rename stop to shutdown

### DIFF
--- a/lib/shelly/cli/main.rb
+++ b/lib/shelly/cli/main.rb
@@ -218,11 +218,13 @@ We have been notified about it. We will be adding new resources shortly}
         say "Your application is set up.", :green
       end
 
-      desc "stop", "Stop the cloud"
+      desc "stop", "Shutdown the cloud"
       method_option :cloud, :type => :string, :aliases => "-c", :desc => "Specify cloud"
       def stop
         multiple_clouds(options[:cloud], "stop")
+        ask_to_stop_application
         @app.stop
+        say_new_line
         say "Cloud '#{@app.code_name}' stopped"
       rescue Client::NotFoundException => e
         raise unless e.resource == :cloud

--- a/lib/shelly/helpers.rb
+++ b/lib/shelly/helpers.rb
@@ -53,6 +53,12 @@ module Shelly
       end
     end
 
+    def ask_to_stop_application
+      stop_question = "Are you sure you want to shut down your application (yes/no):"
+      stop_application = ask(stop_question)
+      exit 1 unless stop_application == "yes"
+    end
+
     def inside_git_repository?
       say_error "Must be run inside your project git repository" unless App.inside_git_repository?
     end

--- a/spec/shelly/cli/main_spec.rb
+++ b/spec/shelly/cli/main_spec.rb
@@ -707,7 +707,7 @@ We have been notified about it. We will be adding new resources shortly")
     end
 
     context "single cloud in Cloudfile" do
-      it "should start the cloud" do
+      it "should stop the cloud" do
         @client.stub(:stop_cloud)
         $stdout.should_receive(:print).with("Are you sure you want to shut down your application (yes/no): ")
         $stdout.should_receive(:puts).with("\n")
@@ -723,7 +723,7 @@ We have been notified about it. We will be adding new resources shortly")
         File.open("Cloudfile", 'w') {|f| f.write("foo-staging:\nfoo-production:\n") }
       end
 
-      it "should show information to start specific cloud and exit" do
+      it "should show information to stop specific cloud and exit" do
         $stdout.should_receive(:puts).with(red "You have multiple clouds in Cloudfile.")
         $stdout.should_receive(:puts).with("Select cloud using `shelly stop --cloud foo-production`")
         $stdout.should_receive(:puts).with("Available clouds:")
@@ -732,7 +732,7 @@ We have been notified about it. We will be adding new resources shortly")
         lambda { invoke(@main, :stop) }.should raise_error(SystemExit)
       end
 
-      it "should fetch from command line which cloud to start" do
+      it "should fetch from command line which cloud to stop" do
         @client.should_receive(:stop_cloud).with("foo-staging")
         $stdout.should_receive(:print).with("Are you sure you want to shut down your application (yes/no): ")
         $stdout.should_receive(:puts).with("\n")


### PR DESCRIPTION
Rename stop to shutdown to make sure users know it's dangerous
