### PR TITLE
Print request id on exceptions.

### DIFF
--- a/lib/shelly/cli/runner.rb
+++ b/lib/shelly/cli/runner.rb
@@ -34,8 +34,7 @@ module Shelly
       rescue Client::APIException => e
         raise if debug?
         say_error "You have found a bug in the shelly gem. We're sorry.",
-          :with_exit => false
-        exit 1 unless e.request_id
+          :with_exit => e.request_id.blank?
         say_error <<-eos
 You can report it to support@shellycloud.com by describing what you wanted
 to do and mentioning error id #{e.request_id}.

--- a/lib/shelly/cli/runner.rb
+++ b/lib/shelly/cli/runner.rb
@@ -31,6 +31,15 @@ module Shelly
         raise if debug?
         say_new_line
         say_error "[canceled]"
+      rescue Client::APIException => e
+        raise if debug?
+        say_error "You have found a bug in the shelly gem. We're sorry.",
+          :with_exit => false
+        exit 1 unless e.request_id
+        say_error <<-eos
+You can report it to support@shellycloud.com by describing what you wanted
+to do and mentioning error id #{e.request_id}.
+        eos
       rescue Exception
         raise if debug?
         say_error "Unknown error, to see debug information run command with --debug"

--- a/lib/shelly/client.rb
+++ b/lib/shelly/client.rb
@@ -5,11 +5,12 @@ require "cgi"
 module Shelly
   class Client
     class APIException < Exception
-      attr_reader :status_code, :body
+      attr_reader :status_code, :body, :request_id
 
-      def initialize(body = {}, status_code = nil)
+      def initialize(body = {}, status_code = nil, request_id = nil)
         @status_code = status_code
         @body = body
+        @request_id = request_id
       end
 
       def [](key)
@@ -234,7 +235,7 @@ module Shelly
         when 422; ValidationException
         else; APIException
         end
-        raise exception_class.new(body, code)
+        raise exception_class.new(body, code, response.headers[:x_request_id])
       end
       response.return!
       body

--- a/spec/shelly/client_spec.rb
+++ b/spec/shelly/client_spec.rb
@@ -363,6 +363,7 @@ describe Shelly::Client do
       it "should raise UnauthorizedException" do
         @response.stub(:code).and_return(401)
         @response.stub(:body).and_return("")
+        @response.stub(:headers).and_return({})
         lambda {
           @client.post("/")
         }.should raise_error(Shelly::Client::UnauthorizedException)
@@ -373,6 +374,7 @@ describe Shelly::Client do
       it "should raise NotFoundException" do
         @response.stub(:code).and_return(404)
         @response.stub(:body).and_return("")
+        @response.stub(:headers).and_return({})
         lambda {
           @client.post("/")
         }.should raise_error(Shelly::Client::NotFoundException)
@@ -383,6 +385,7 @@ describe Shelly::Client do
       it "should raise ConflictException" do
         @response.stub(:code).and_return(409)
         @response.stub(:body).and_return("")
+        @response.stub(:headers).and_return({})
         lambda {
           @client.post("/")
         }.should raise_error(Shelly::Client::ConflictException)
@@ -393,6 +396,7 @@ describe Shelly::Client do
       it "should raise ValidationException" do
         @response.stub(:code).and_return(422)
         @response.stub(:body).and_return("")
+        @response.stub(:headers).and_return({})
         lambda {
           @client.post("/")
         }.should raise_error(Shelly::Client::ValidationException)
@@ -403,9 +407,13 @@ describe Shelly::Client do
       it "should raise generic APIException" do
         @response.stub(:code).and_return(500)
         @response.stub(:body).and_return("")
+        @response.stub(:headers).and_return({:x_request_id => "id123"})
         lambda {
           @client.post("/")
-        }.should raise_error(Shelly::Client::APIException)
+        }.should raise_error { |error|
+          error.should be_a(Shelly::Client::APIException)
+          error.request_id.should == "id123"
+        }
       end
     end
 
@@ -413,6 +421,7 @@ describe Shelly::Client do
       JSON.should_receive(:parse).with("").and_raise(JSON::ParserError)
       @response.stub(:code).and_return("204")
       @response.stub(:body).and_return("")
+      @response.stub(:headers).and_return({})
       @client.post("/api/apps/flower").should == {}
     end
   end


### PR DESCRIPTION
When a user starts an action that results in exception, we now capture the exception's uuid and print it to the user, so that he can report it to us.

[#28812545]
