### PR TITLE
Allow to use last shelly-dependencies.

### DIFF
--- a/lib/shelly/version.rb
+++ b/lib/shelly/version.rb
@@ -1,3 +1,3 @@
 module Shelly
-  VERSION = "0.1.15"
+  VERSION = "0.1.16"
 end

--- a/lib/shelly/version.rb
+++ b/lib/shelly/version.rb
@@ -1,3 +1,3 @@
 module Shelly
-  VERSION = "0.1.16"
+  VERSION = "0.1.15"
 end

--- a/shelly.gemspec
+++ b/shelly.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "progressbar"
   s.add_runtime_dependency "grit"
   s.add_runtime_dependency "launchy"
-  s.add_runtime_dependency "shelly-dependencies", "~> 0.1.1"
+  s.add_runtime_dependency "shelly-dependencies", "~> 0.2.1"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
In case when you have installed "shelly-dependencies" gem in last
version "0.2.1" you cannot bump version of "shelly" gem beyond "0.0.63".

After forcing Gemfile to use "0.1.15" version i got this:

Bundler could not find compatible versions for gem "shelly-dependencies":
  In Gemfile:
    shelly (= 0.1.15) ruby depends on
      shelly-dependencies (~> 0.1.1) ruby

```
shelly-dependencies (0.2.1)
```
