### PR TITLE
Ask user to choose organization when adding cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* [feature] Let user choose organization when adding new cloud
+
 * [feature] When displaying user list, `--organization=ORGANIZATION_NAME` limits the list to users from a single organization
 
 * [feature] Support for deleting files from disk - `shelly file delete`

--- a/lib/shelly/cli/user.rb
+++ b/lib/shelly/cli/user.rb
@@ -24,7 +24,7 @@ module Shelly
           if organization.memberships.present?
             members_table = organization.owners.map { |owner| [owner["email"], "  | owner"] }
             members_table += organization.members.map { |member| [member["email"], "  | member"] }
-            members_table += organization.inactive_members.map { |inactive| [inactive["email"] + " (invited)", "  | #{humman_owner(inactive["owner"])}"] }
+            members_table += organization.inactive_members.map { |inactive| [inactive["email"] + " (invited)", "  | #{human_owner(inactive["owner"])}"] }
             print_table(members_table, :ident => 2, :colwidth => 45)
             say_new_line
           end
@@ -86,7 +86,7 @@ module Shelly
       end
 
       no_tasks do
-        def humman_owner(owner)
+        def human_owner(owner)
           owner ? "owner" : "member"
         end
 


### PR DESCRIPTION
[#41017885]

```
~ $ shelly_local add    
Cloud code name (foo-production - default): 
Which database do you want to use postgresql, mongodb, redis, none (postgresql - default): 
You have access to the following organizations:
  test_app
  foo-production
  todo-list-test
  shelly-app-testing
Do you want to add this cloud to organization? y
Organization name: test
```
