### PR TITLE
Change output of `shelly backup list`

### DIFF
--- a/lib/shelly/cli/backup.rb
+++ b/lib/shelly/cli/backup.rb
@@ -23,7 +23,7 @@ module Shelly
           limit = 0
           unless options[:all] || backups.count < (Shelly::Backup::LIMIT + 1)
             limit = Shelly::Backup::LIMIT - 1
-            say "Showing only #{Shelly::Backup::LIMIT} backups."
+            say "Showing only last #{Shelly::Backup::LIMIT} backups.", :green
             say "Use --all or -a option to list all backups."
           end
           to_display = [["Filename", "|  Size", "|  State"]]
@@ -31,7 +31,6 @@ module Shelly
             to_display << [backup.filename, "|  #{backup.human_size}", "|  #{backup.state.humanize}"]
           end
 
-          say "Available backups:", :green
           say_new_line
           print_table(to_display, :ident => 2)
         else

--- a/spec/shelly/cli/backup_spec.rb
+++ b/spec/shelly/cli/backup_spec.rb
@@ -46,7 +46,6 @@ describe Shelly::CLI::Backup do
          {"filename" => "backup.mongo.tar.gz", "human_size" => "22kb",
           "size" => 333, "state" => "in_progress"}])
       $stdout.should_not_receive(:puts).with("Limiting the number of backups to 1.")
-      $stdout.should_receive(:puts).with(green "Available backups:")
       $stdout.should_receive(:puts).with("\n")
       $stdout.should_receive(:puts).with("  Filename               |  Size  |  State")
       $stdout.should_receive(:puts).with("  backup.postgre.tar.gz  |  10kb  |  completed")
@@ -57,7 +56,7 @@ describe Shelly::CLI::Backup do
 
     it "should show --all option if not present" do
       stub_const("Shelly::Backup::LIMIT", 1)
-      $stdout.should_receive(:puts).with("Showing only 1 backups.")
+      $stdout.should_receive(:puts).with(green "Showing only last 1 backups.")
       $stdout.should_receive(:puts).with("Use --all or -a option to list all backups.")
       @client.should_receive(:database_backups).with("foo-staging").and_return(
           [{"filename" => "backup.postgre.tar.gz", "human_size" => "10kb",


### PR DESCRIPTION
I changed header in`shelly backup list` output, instead of:

![12bfe846-9206-11e2-95ff-eabfeeb5e66e](https://f.cloud.github.com/assets/127219/284945/01c3d6b8-9208-11e2-9a8f-f21ba2b92198.png)

display this:

![198d9ff6-9206-11e2-8f91-576c1c8c1970](https://f.cloud.github.com/assets/127219/284946/0631532e-9208-11e2-90dd-eac919192185.png)
