### PR TITLE
Shelly check allows puma or thin as web server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* [bug] shelly check recognizes puma as allowed web server
+
 ## 0.2.11 / 2013-03-22
 
 * [bug] Zone option should be string, `shelly add` option fix

--- a/lib/shelly/cli/main.rb
+++ b/lib/shelly/cli/main.rb
@@ -439,8 +439,10 @@ Wait until cloud is in 'turned off' state and try again.}
           "Gem 'shelly-dependencies' is missing, we recommend to install it\n    See more at https://shellycloud.com/documentation/requirements#shelly-dependencies",
           :show_fulfilled => verbose || structure.warnings?, :failure_level => :warning)
 
-        print_check(structure.gem?("thin"), "Gem 'thin' is present",
-          "Gem 'thin' is missing in the Gemfile", :show_fulfilled => verbose)
+        print_check(structure.gem?("thin") || structure.gem?("puma"),
+          "Web server gem is present",
+          "Missing web server gem in Gemfile. Currently supported: 'thin' and 'puma'",
+          :show_fulfilled => verbose)
 
         print_check(structure.gem?("rake"), "Gem 'rake' is present",
           "Gem 'rake' is missing in the Gemfile", :show_fulfilled => verbose)

--- a/spec/shelly/cli/main_spec.rb
+++ b/spec/shelly/cli/main_spec.rb
@@ -1481,18 +1481,29 @@ Wait until cloud is in 'turned off' state and try again.")
       end
     end
 
-    context "when thin gem exists" do
-      it "should show that necessary gem exists" do
-        $stdout.should_receive(:puts).with("  #{green("✓")} Gem 'thin' is present")
-        invoke(@main, :check)
+    context "application server" do
+      context "when thin gem exists" do
+        it "should show that necessary gem exists" do
+          $stdout.should_receive(:puts).with("  #{green("✓")} Web server gem is present")
+          invoke(@main, :check)
+        end
       end
-    end
 
-    context "when thin gem doesn't exist" do
-      it "should show that necessary gem doesn't exist" do
-        Bundler::Definition.stub_chain(:build, :specs, :map).and_return([])
-        $stdout.should_receive(:puts).with("  #{red("✗")} Gem 'thin' is missing in the Gemfile")
-        invoke(@main, :check)
+      context "when puma gem exists" do
+        it "should show that necessary gem exists" do
+          Bundler::Definition.stub_chain(:build, :specs, :map) \
+            .and_return(["puma", "pg", "delayed_job", "whenever", "sidekiq"])
+          $stdout.should_receive(:puts).with("  #{green("✓")} Web server gem is present")
+          invoke(@main, :check)
+        end
+      end
+
+      context "when neither thin nor puma present in Gemfile" do
+        it "should show that necessary gem doesn't exist" do
+          Bundler::Definition.stub_chain(:build, :specs, :map).and_return([])
+          $stdout.should_receive(:puts).with("  #{red("✗")} Missing web server gem in Gemfile. Currently supported: 'thin' and 'puma'")
+          invoke(@main, :check)
+        end
       end
     end
 


### PR DESCRIPTION
Wording could be better here. Both puma and thin are described as 'web servers' on their websites, but we use the term 'application server' on ours. We should use one in every place, but which? I'm opting for 'web server'... Thin is a web server, stuff like torquebox is an application server.
