### PR TITLE
Fixed structure validator (recognizes puma as allowed web server).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* [bug] Structure validator recognizes puma as allowed web server
+
 ## 0.2.13 / 2013-03-28
 
 * [improvement] More verbose output for redeploy, start and stop

--- a/lib/shelly/structure_validator.rb
+++ b/lib/shelly/structure_validator.rb
@@ -33,9 +33,9 @@ module Shelly
 
     # Public: Check all requirements that app has to fulfill
     def valid?
-      gemfile? && gemfile_lock? && gem?("thin") &&
-        gem?("rake") && config_ru? && rakefile? &&
-        task?("db:migrate") && task?("db:setup")
+      gemfile? && gemfile_lock? && gem?("rake") &&
+        (gem?("thin") || gem?("puma")) && config_ru? &&
+        rakefile? && task?("db:migrate") && task?("db:setup")
     end
 
     def invalid?


### PR DESCRIPTION
The problem was in the `valid?` method, which does not recognize `puma` as allowed web server so `shelly add` and `shelly check` received `false` from `valid?` method

![gemfile](https://f.cloud.github.com/assets/619324/313291/b7f3a54a-97a7-11e2-835c-321a4cb71e88.PNG)
![add](https://f.cloud.github.com/assets/619324/313293/ba40bd7e-97a7-11e2-9fe1-e339030da4df.PNG)
![check](https://f.cloud.github.com/assets/619324/313294/bc360044-97a7-11e2-8ea1-a2c699282886.PNG)
