### PR TITLE
JRuby fixes for shelly add

### DIFF
--- a/lib/shelly/app.rb
+++ b/lib/shelly/app.rb
@@ -17,6 +17,10 @@ module Shelly
       self.content = content
     end
 
+    def thin
+      size == "small" ? 2 : 4
+    end
+
     def databases=(dbs)
       @databases = dbs - ['none']
     end
@@ -61,6 +65,7 @@ module Shelly
       cloudfile.environment = environment
       cloudfile.domains = domains
       cloudfile.size = size
+      cloudfile.thin = thin
       cloudfile.databases = databases
       cloudfile.create
     end

--- a/lib/shelly/app.rb
+++ b/lib/shelly/app.rb
@@ -52,10 +52,7 @@ module Shelly
                     :organization_name => organization,
                     :zone_name => zone_name}
       response = shelly.create_app(attributes)
-      self.git_url = response["git_url"]
-      self.domains = response["domains"]
-      self.ruby_version = response["ruby_version"]
-      self.environment = response["environment"]
+      assign_attributes(response)
     end
 
     def create_cloudfile
@@ -297,6 +294,17 @@ module Shelly
     end
 
     private
+
+    def assign_attributes(response)
+      self.git_url = response["git_url"]
+      self.domains = response["domains"]
+      self.ruby_version = jruby? ? 'jruby' : response["ruby_version"]
+      self.environment = response["environment"]
+    end
+
+    def jruby?
+      RUBY_PLATFORM == 'java'
+    end
 
     # Internal: Checks if specified option is present in Cloudfile
     def option?(option)

--- a/lib/shelly/app.rb
+++ b/lib/shelly/app.rb
@@ -21,6 +21,10 @@ module Shelly
       size == "small" ? 2 : 4
     end
 
+    def puma
+      size == "small" ? 1 : 2
+    end
+
     def databases=(dbs)
       @databases = dbs - ['none']
     end
@@ -62,7 +66,11 @@ module Shelly
       cloudfile.environment = environment
       cloudfile.domains = domains
       cloudfile.size = size
-      cloudfile.thin = thin
+      if ruby_version == 'jruby'
+        cloudfile.puma = puma
+      else
+        cloudfile.thin = thin
+      end
       cloudfile.databases = databases
       cloudfile.create
     end

--- a/lib/shelly/cloudfile.rb
+++ b/lib/shelly/cloudfile.rb
@@ -5,7 +5,7 @@ module Shelly
     attr_accessor :content
     # Cloudfile attributes used for generating Cloudfile from a template
     attr_accessor :code_name, :ruby_version, :environment, :domains,
-      :databases, :size, :thin
+      :databases, :size, :thin, :puma
 
     # Public: Return true if Cloudfile is present in current directory
     def present?

--- a/lib/shelly/cloudfile.rb
+++ b/lib/shelly/cloudfile.rb
@@ -5,7 +5,7 @@ module Shelly
     attr_accessor :content
     # Cloudfile attributes used for generating Cloudfile from a template
     attr_accessor :code_name, :ruby_version, :environment, :domains,
-      :databases, :size
+      :databases, :size, :thin
 
     # Public: Return true if Cloudfile is present in current directory
     def present?
@@ -25,7 +25,6 @@ module Shelly
     # Returns the generated Cloudfile as String
     def generate
       @email = current_user.email
-      @thin = @size == "small" ? 2 : 4
       template = File.read(template_path)
       cloudfile = ERB.new(template, nil, "%<>-")
       cloudfile.result(binding)

--- a/lib/shelly/templates/Cloudfile.erb
+++ b/lib/shelly/templates/Cloudfile.erb
@@ -1,5 +1,5 @@
 <%= @code_name %>:
-  ruby_version: <%= @ruby_version %> # 2.0.0, 1.9.3, 1.9.2 or ree-1.8.7
+  ruby_version: <%= @ruby_version %> # 2.0.0, jruby, 1.9.3, 1.9.2 or ree-1.8.7
   environment: <%= @environment %> # RAILS_ENV
   monitoring_email: <%= @email %>
   domains:

--- a/lib/shelly/templates/Cloudfile.erb
+++ b/lib/shelly/templates/Cloudfile.erb
@@ -13,7 +13,12 @@
   servers:
     app1:
       size: <%= @size %>
+      <%- if @thin -%>
       thin: <%= @thin %>
+      <%- end -%>
+      <%- if @puma -%>
+      puma: <%= @puma %>
+      <%- end -%>
       # whenever: on
       # delayed_job: 1
       databases:

--- a/spec/shelly/app_spec.rb
+++ b/spec/shelly/app_spec.rb
@@ -398,6 +398,7 @@ describe Shelly::App do
       cloudfile.should_receive(:environment=).with("production")
       cloudfile.should_receive(:domains=).with(["example.com", "another.example.com"])
       cloudfile.should_receive(:size=).with("large")
+      cloudfile.should_receive(:thin=).with(4)
       cloudfile.should_receive(:databases=).with([])
       cloudfile.should_receive(:create)
       Shelly::Cloudfile.should_receive(:new).and_return(cloudfile)

--- a/spec/shelly/app_spec.rb
+++ b/spec/shelly/app_spec.rb
@@ -395,22 +395,35 @@ describe Shelly::App do
   end
 
   describe "#create_cloudfile" do
-    it "should create cloudfile with app attributes" do
-      @app.ruby_version = "1.9.3"
+    before do
       @app.environment = "production"
       @app.domains = ["example.com", "another.example.com"]
       @app.size = "large"
       @app.databases = []
-      cloudfile = mock
-      cloudfile.should_receive(:code_name=).with("foo-staging")
-      cloudfile.should_receive(:ruby_version=).with("1.9.3")
-      cloudfile.should_receive(:environment=).with("production")
-      cloudfile.should_receive(:domains=).with(["example.com", "another.example.com"])
-      cloudfile.should_receive(:size=).with("large")
-      cloudfile.should_receive(:thin=).with(4)
-      cloudfile.should_receive(:databases=).with([])
-      cloudfile.should_receive(:create)
-      Shelly::Cloudfile.should_receive(:new).and_return(cloudfile)
+      @cloudfile = mock(:code_name= => nil, :ruby_version= => nil,
+        :environment= => nil, :domains= => nil, :size= => nil, :thin= => nil,
+        :puma= => nil, :databases= => nil, :create => nil)
+      Shelly::Cloudfile.should_receive(:new).and_return(@cloudfile)
+    end
+
+    it "should create cloudfile with app attributes" do
+      @app.ruby_version = "1.9.3"
+      @cloudfile.should_receive(:code_name=).with("foo-staging")
+      @cloudfile.should_receive(:ruby_version=).with("1.9.3")
+      @cloudfile.should_receive(:environment=).with("production")
+      @cloudfile.should_receive(:domains=).with(["example.com", "another.example.com"])
+      @cloudfile.should_receive(:size=).with("large")
+      @cloudfile.should_receive(:thin=).with(4)
+      @cloudfile.should_not_receive(:puma=)
+      @cloudfile.should_receive(:databases=).with([])
+      @cloudfile.should_receive(:create)
+      @app.create_cloudfile
+    end
+
+    it "should set puma instead of thin under jruby" do
+      @app.ruby_version = "jruby"
+      @cloudfile.should_not_receive(:thin=)
+      @cloudfile.should_receive(:puma=).with(2)
       @app.create_cloudfile
     end
   end

--- a/spec/shelly/app_spec.rb
+++ b/spec/shelly/app_spec.rb
@@ -280,11 +280,20 @@ describe Shelly::App do
     it "should assign returned git_url, domains, ruby_version and environment" do
       @client.stub(:create_app).and_return("git_url" => "git@git.example.com:fooo.git",
         "domains" => ["fooo.shellyapp.com"], "ruby_version" => "1.9.2", "environment" => "production")
+      stub_const('RUBY_PLATFORM', 'i686-linux')
       @app.create
       @app.git_url.should == "git@git.example.com:fooo.git"
       @app.domains.should == ["fooo.shellyapp.com"]
       @app.ruby_version.should == "1.9.2"
       @app.environment.should == "production"
+    end
+
+    it "should assign jruby as ruby_version if gem is running under jruby" do
+      @client.stub(:create_app).and_return("git_url" => nil,
+        "domains" => nil, "environment" => nil, "ruby_version" => "1.9.2")
+      stub_const('RUBY_PLATFORM', 'java')
+      @app.create
+      @app.ruby_version.should == "jruby"
     end
   end
 

--- a/spec/shelly/cloudfile_spec.rb
+++ b/spec/shelly/cloudfile_spec.rb
@@ -109,7 +109,7 @@ config
         FakeFS.deactivate!
         expected = <<-config
 foo-staging:
-  ruby_version: 1.9.3 # 2.0.0, 1.9.3, 1.9.2 or ree-1.8.7
+  ruby_version: 1.9.3 # 2.0.0, jruby, 1.9.3, 1.9.2 or ree-1.8.7
   environment: production # RAILS_ENV
   monitoring_email: bob@example.com
   domains:
@@ -137,7 +137,7 @@ config
         @cloudfile.size = "small"
         expected = <<-config
 foo-staging:
-  ruby_version: 1.9.3 # 2.0.0, 1.9.3, 1.9.2 or ree-1.8.7
+  ruby_version: 1.9.3 # 2.0.0, jruby, 1.9.3, 1.9.2 or ree-1.8.7
   environment: production # RAILS_ENV
   monitoring_email: bob@example.com
   domains:

--- a/spec/shelly/cloudfile_spec.rb
+++ b/spec/shelly/cloudfile_spec.rb
@@ -101,6 +101,7 @@ config
       @cloudfile.ruby_version = "1.9.3"
       @cloudfile.environment = "production"
       @cloudfile.size = "large"
+      @cloudfile.thin = 4
       @cloudfile.stub(:current_user => mock(:email => "bob@example.com"))
     end
 
@@ -135,6 +136,7 @@ config
       it "should generate sample Cloudfile with given attributes and 2 thins" do
         FakeFS.deactivate!
         @cloudfile.size = "small"
+        @cloudfile.thin = 2
         expected = <<-config
 foo-staging:
   ruby_version: 1.9.3 # 2.0.0, jruby, 1.9.3, 1.9.2 or ree-1.8.7


### PR DESCRIPTION
When shelly is used under JRuby the generated Cloudfile has ruby_version set to "jruby" and puma used instead of thin.
