### PR TITLE
[#45319727] More detailed app state descriptions.

### DIFF
--- a/lib/shelly/app.rb
+++ b/lib/shelly/app.rb
@@ -17,6 +17,16 @@ module Shelly
       self.content = content
     end
 
+    def self.from_attributes(attributes)
+      new(attributes["code_name"]).tap do |app|
+        app.attributes = attributes
+      end
+    end
+
+    def attributes=(attributes)
+      @attributes = attributes
+    end
+
     def thin
       size == "small" ? 2 : 4
     end
@@ -208,6 +218,10 @@ module Shelly
 
     def state
       attributes["state"]
+    end
+
+    def state_description
+      attributes["state_description"]
     end
 
     def credit

--- a/lib/shelly/cli/main.rb
+++ b/lib/shelly/cli/main.rb
@@ -153,14 +153,7 @@ module Shelly
         apps = user.apps
         unless apps.empty?
           say "You have following clouds available:", :green
-          apps_table = apps.map do |app|
-            state = app["state"]
-            msg = if state == "deploy_failed" || state == "configuration_failed"
-              " (deployment log: `shelly deploys show last -c #{app["code_name"]}`)"
-            end
-            [app["code_name"], "|  #{state.humanize}#{msg}"]
-          end
-          print_table(apps_table, :ident => 2)
+          print_table(apps_table(apps), :ident => 2)
         else
           say "You have no clouds yet", :green
         end
@@ -175,7 +168,7 @@ module Shelly
           " (deployment log: `shelly deploys show last -c #{app}`)"
         end
         say "Cloud #{app}:", msg.present? ? :red : :green
-        print_wrapped "State: #{app.state}#{msg}", :ident => 2
+        print_wrapped "State: #{app.state_description}#{msg}", :ident => 2
         say_new_line
         print_wrapped "Deployed commit sha: #{app.git_info["deployed_commit_sha"]}", :ident => 2
         print_wrapped "Deployed commit message: #{app.git_info["deployed_commit_message"]}", :ident => 2

--- a/lib/shelly/cli/organization.rb
+++ b/lib/shelly/cli/organization.rb
@@ -17,14 +17,7 @@ module Shelly
         organizations.each do |organization|
           say organization.name, :green
           if organization.apps.present?
-            apps_table = organization.apps.map do |app|
-              state = app.state
-              msg = if state == "deploy_failed" || state == "configuration_failed"
-                " (deployment log: `shelly deploys show last -c #{app["code_name"]}`)"
-              end
-              [app.to_s, "|  #{state.humanize}#{msg}"]
-            end
-            print_table(apps_table, :ident => 2, :colwidth => 35)
+            print_table(apps_table(organization.apps), :ident => 2, :colwidth => 35)
           else
             print_wrapped "No clouds", :ident => 2
           end

--- a/lib/shelly/helpers.rb
+++ b/lib/shelly/helpers.rb
@@ -164,5 +164,14 @@ More info at http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository}
         say "#{action_name} failed. See logs with `shelly deploy show last --cloud #{app}`", :red
       end
     end
+
+    def apps_table(apps)
+      apps.map do |app|
+        msg = if app.state == "deploy_failed" || app.state == "configuration_failed"
+          " (deployment log: `shelly deploys show last -c #{app.code_name}`)"
+        end
+        [app.code_name, "|  #{app.state_description}#{msg}"]
+      end
+    end
   end
 end

--- a/lib/shelly/user.rb
+++ b/lib/shelly/user.rb
@@ -10,7 +10,9 @@ module Shelly
     end
 
     def apps
-      shelly.apps
+      shelly.apps.map do |attributes|
+        Shelly::App.from_attributes(attributes)
+      end
     end
 
     def organizations

--- a/spec/shelly/user_spec.rb
+++ b/spec/shelly/user_spec.rb
@@ -177,7 +177,7 @@ describe Shelly::User do
 
   describe "#apps" do
     it "should fetch list of apps via API client" do
-      @client.should_receive(:apps)
+      @client.should_receive(:apps).and_return([])
       @user.apps
     end
   end


### PR DESCRIPTION
shelly info, shelly list and shelly organization list now uses the new
state_description attribute returned by Shelly API.

Extracted duplicate code into apps_table helper method.

User#apps now returns an array of Shelly::App objects instead of array
of Hashes for consistency with the rest of the code and ease of use.
