### PR TITLE
User is not asked for billing for existing org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* [bug] `shelly add` doesn't prompt the user to provide billing details when adding to existing organization.
+
 ## 0.2.17 / 2013-04-12
 
 * [feature] Added '--cloud code_name' to command given in output after failed `shelly redeploy` and `shelly stop`.

--- a/lib/shelly/app.rb
+++ b/lib/shelly/app.rb
@@ -214,6 +214,10 @@ module Shelly
       attributes["organization"]["credit"].to_f
     end
 
+    def organization_details_present?
+      attributes["organization"]["details_present"]
+    end
+
     def self.inside_git_repository?
       system("git status > /dev/null 2>&1")
     end

--- a/lib/shelly/cli/main.rb
+++ b/lib/shelly/cli/main.rb
@@ -116,12 +116,16 @@ module Shelly
 
         say "Creating Cloudfile", :green
         app.create_cloudfile
-        if app.credit > 0
+        if app.credit > 0 || !app.organization_details_present?
           say_new_line
           say "Billing information", :green
-          say "Cloud created with #{app.credit.to_i} Euro credit."
-          say "Remember to provide billing details before trial ends."
-          say app.edit_billing_url
+          if app.credit > 0
+            say "#{app.credit.to_i} Euro credit remaining."
+          end
+          if !app.organization_details_present?
+            say "Remember to provide billing details before trial ends."
+            say app.edit_billing_url
+          end
         end
 
         info_adding_cloudfile_to_repository

--- a/spec/shelly/app_spec.rb
+++ b/spec/shelly/app_spec.rb
@@ -134,7 +134,8 @@ describe Shelly::App do
       @response = {"web_server_ip" => "192.0.2.1",
                    "state" => "running",
                    "organization" => {
-                     "credit" => 23.0
+                     "credit" => 23.0,
+                     "details_present" => true
                    },
                    "git_info" => {
                      "deployed_commit_message" => "Commit message",
@@ -145,8 +146,14 @@ describe Shelly::App do
     end
 
     describe "#credit" do
-      it "should return freecredit that app has" do
+      it "should return free credit that app has" do
         @app.credit.should == 23.0
+      end
+    end
+
+    describe "#organization_details_present?" do
+      it "should return app's organization's details_present?" do
+        @app.organization_details_present?.should == true
       end
     end
 


### PR DESCRIPTION
When user adds a cloud to existing organization, the notice to provide
billing details is not shown for organizations with credit and billing
details provided.

[#48240839]
