### PR TITLE
Warn users that public SSH key will be uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* [improvement] warn user that his public SSH key will be uploaded on login and register.
+
 ## 0.2.18 / 2013-04-25
 
 * [bug] `shelly add` doesn't prompt the user to provide billing details when adding to existing organization.

--- a/lib/shelly/cli/main.rb
+++ b/lib/shelly/cli/main.rb
@@ -32,6 +32,7 @@ module Shelly
       desc "register [EMAIL]", "Register new account"
       def register(email = nil)
         user = Shelly::User.new
+        say "Your public SSH key will be uploaded to Shelly Cloud after registration."
         say "Registering with email: #{email}" if email
         user.email = (email || ask_for_email)
         user.password = ask_for_password
@@ -53,6 +54,7 @@ module Shelly
       desc "login [EMAIL]", "Log into Shelly Cloud"
       def login(email = nil)
         user = Shelly::User.new
+        say "Your public SSH key will be uploaded to Shelly Cloud after login."
         raise Errno::ENOENT, user.ssh_key_path unless user.ssh_key_exists?
         user.email = email || ask_for_email
         user.password = ask_for_password(:with_confirmation => false)


### PR DESCRIPTION
before `shelly login` and `shelly register`

[#48725673]
