### PR TITLE
Allow user to print all logs from a specific date.

### DIFF
--- a/lib/shelly/cli/logs.rb
+++ b/lib/shelly/cli/logs.rb
@@ -1,0 +1,47 @@
+require "shelly/cli/command"
+
+module Shelly
+  module CLI
+    class Logs < Command
+      namespace :logs
+      include Helpers
+
+      before_hook :logged_in?, :only => [:latest, :date]
+      class_option :cloud, :type => :string, :aliases => "-c", :desc => "Specify cloud"
+
+      desc "latest", "Show latest application logs"
+      method_option :limit, :type => :numeric, :aliases => "-n", :desc => "Amount of messages to show"
+      method_option :from, :type => :string, :desc => "Time from which to find the logs"
+      method_option :source, :type => :string, :aliases => "-s", :desc => "Limit logs to a single source, e.g. nginx"
+      method_option :tail, :type => :boolean, :aliases => "-f", :desc => "Show new logs automatically"
+      def latest
+        cloud = options[:cloud]
+        app = multiple_clouds(cloud, "logs latest")
+        limit = options[:limit].to_i <= 0 ? 100 : options[:limit]
+        query = {:limit => options[:limit], :source => options[:source]}
+        query.merge!(:from => options[:from]) if options[:from]
+
+        logs = app.application_logs(query)
+        print_logs(logs)
+
+        if options[:tail]
+          app.application_logs_tail { |logs| print logs }
+        end
+      rescue Client::APIException => e
+        raise e unless e.status_code == 416
+        say_error "You have requested too many log messages. Try a lower number."
+      end
+
+      desc "date [DATE]", "Show logs from a specific day"
+      method_option :source, :type => :string, :aliases => "-s", :desc => "Limit logs to a single source, e.g. nginx"
+      def date(day = "today")
+        cloud = options[:cloud]
+        app = multiple_clouds(cloud, "logs date #{day}")
+
+        query = {:date => day, :source => options[:source]}
+        logs = app.application_logs(query)
+        print_logs(logs)
+      end
+    end
+  end
+end

--- a/lib/shelly/cli/main.rb
+++ b/lib/shelly/cli/main.rb
@@ -6,6 +6,7 @@ require "shelly/cli/deploy"
 require "shelly/cli/config"
 require "shelly/cli/file"
 require "shelly/cli/organization"
+require "shelly/cli/logs"
 
 module Shelly
   module CLI
@@ -16,11 +17,12 @@ module Shelly
       register_subcommand(Config, "config", "config <command>", "Manage application configuration files")
       register_subcommand(File, "file", "file <command>", "Upload and download files to and from persistent storage")
       register_subcommand(Organization, "organization", "organization <command>", "View organizations")
+      register_subcommand(Logs, "logs", "logs <command>", "View application logs")
 
       check_unknown_options!(:except => :rake)
 
       # FIXME: it should be possible to pass single symbol, instead of one element array
-      before_hook :logged_in?, :only => [:add, :status, :list, :start, :stop, :logs, :delete, :info, :ip, :logout, :execute, :rake, :setup, :console, :dbconsole]
+      before_hook :logged_in?, :only => [:add, :status, :list, :start, :stop, :delete, :info, :ip, :logout, :execute, :rake, :setup, :console, :dbconsole]
       before_hook :inside_git_repository?, :only => [:add, :setup, :check]
 
       map %w(-v --version) => :version
@@ -308,31 +310,6 @@ Wait until cloud is in 'turned off' state and try again.}
         end
       rescue Client::ConflictException => e
         say_error e[:message]
-      end
-
-      desc "logs", "Show latest application logs"
-      method_option :cloud, :type => :string, :aliases => "-c", :desc => "Specify cloud"
-      method_option :limit, :type => :numeric, :aliases => "-n", :desc => "Amount of messages to show"
-      method_option :from, :type => :string, :desc => "Time from which to find the logs"
-      method_option :source, :type => :string, :aliases => "-s", :desc => "Limit logs to a single source, e.g. nginx"
-      method_option :tail, :type => :boolean, :aliases => "-f", :desc => "Show new logs automatically"
-      def logs
-        cloud = options[:cloud]
-        app = multiple_clouds(cloud, "logs")
-        limit = options[:limit].to_i <= 0 ? 100 : options[:limit]
-        query = {:limit => limit, :source => options[:source]}
-        query.merge!(:from => options[:from]) if options[:from]
-
-        logs = app.application_logs(query)
-        print_logs(logs)
-
-        if options[:tail]
-          app.application_logs_tail { |logs| print logs }
-        end
-
-      rescue Client::APIException => e
-        raise e unless e.status_code == 416
-        say_error "You have requested too many log messages. Try a lower number."
       end
 
       desc "logout", "Logout from Shelly Cloud"

--- a/spec/shelly/cli/logs_spec.rb
+++ b/spec/shelly/cli/logs_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+require "shelly/cli/logs"
+
+describe Shelly::CLI::Logs do
+  before do
+    @cli_logs = Shelly::CLI::Logs.new
+    Shelly::CLI::Logs.stub(:new).and_return(@cli_logs)
+    @client = mock
+    Shelly::Client.stub(:new).and_return(@client)
+    @client.stub(:token).and_return("abc")
+    FileUtils.mkdir_p("/projects/foo")
+    Dir.chdir("/projects/foo")
+    @app = Shelly::App.new("foo-production")
+    Shelly::App.stub(:new).and_return(@app)
+    File.open("Cloudfile", 'w') { |f| f.write("foo-production:\n") }
+    $stdout.stub(:puts)
+    $stdout.stub(:print)
+    @sample_logs = {"entries" => [['app1', 'log1'], ['app1', 'log2']]}
+  end
+
+  describe "#latest" do
+    it "should ensure user has logged in" do
+      hooks(@cli_logs, :latest).should include(:logged_in?)
+    end
+
+    it "should ensure multiple_clouds check" do
+      @client.stub(:application_logs).and_return(@sample_logs)
+      @cli_logs.should_receive(:multiple_clouds).and_return(@app)
+      invoke(@cli_logs, :latest)
+    end
+
+    it "should exit if user requested too many log lines" do
+      exception = Shelly::Client::APIException.new({}, 416)
+      @client.stub(:application_logs).and_raise(exception)
+      $stdout.should_receive(:puts).
+        with(red "You have requested too many log messages. Try a lower number.")
+      lambda { invoke(@cli_logs, :latest) }.should raise_error(SystemExit)
+    end
+
+    it "should show logs for the cloud" do
+      @client.stub(:application_logs).and_return(@sample_logs)
+      $stdout.should_receive(:puts).with("app1 log1")
+      $stdout.should_receive(:puts).with("app1 log2")
+      invoke(@cli_logs, :latest)
+    end
+
+    it "should show requested amount of logs" do
+      @client.should_receive(:application_logs).
+        with("foo-production", {:limit => 2, :source => 'nginx'}).and_return(@sample_logs)
+      @cli_logs.options = {:limit => 2, :source => 'nginx'}
+      invoke(@cli_logs, :latest)
+    end
+
+    it "should show logs since 2013-05-07" do
+      @client.should_receive(:application_logs).
+        with("foo-production", {:from => '2013-05-07', :source => 'nginx', :limit => 2}).
+        and_return(@sample_logs)
+      @cli_logs.options = {:from => '2013-05-07', :source => 'nginx', :limit => 2}
+      invoke(@cli_logs, :latest)
+    end
+  end
+
+  describe "#date" do
+    it "should ensure user has logged in" do
+      hooks(@cli_logs, :date).should include(:logged_in?)
+    end
+
+    it "should ensure multiple_clouds check" do
+      @client.stub(:application_logs).and_return(@sample_logs)
+      @cli_logs.should_receive(:multiple_clouds).and_return(@app)
+      invoke(@cli_logs, :date)
+    end
+
+    it "should show logs for 2013-05-07" do
+      @client.should_receive(:application_logs).
+        with("foo-production", {:date => '2013-05-07', :source => nil}).
+        and_return(@sample_logs)
+      $stdout.should_receive(:puts).with("app1 log1")
+      $stdout.should_receive(:puts).with("app1 log2")
+      invoke(@cli_logs, :date, '2013-05-07')
+    end
+  end
+end


### PR DESCRIPTION
**WIP!**

Moved **class logs** to separate file (`lib/shelly/cli/logs.rb`). Splited `shelly logs` into two commands:
- `shelly logs latest` - this is copy of previous `shelly logs` which allows user to print latest logs.
- `shelly logs date [DATE]` - which allows user to print all logs from a specific date.
