### PR TITLE
Added arrows for remote messages given by `shelly start/stop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* [improvement] consistent output for `shelly start`, `shelly stop` and deployment progress
+
 ## 0.3.3 / 2013-06-28
 
 * [feature] user is able to access MongoDB console

--- a/lib/shelly/cli/main.rb
+++ b/lib/shelly/cli/main.rb
@@ -196,6 +196,7 @@ module Shelly
         app = multiple_clouds(options[:cloud], "start")
         deployment_id = app.start
         say "Starting cloud #{app}.", :green
+        say_new_line
         deployment_progress(app, deployment_id, "Starting cloud")
       rescue Client::ConflictException => e
         case e[:state]

--- a/lib/shelly/helpers.rb
+++ b/lib/shelly/helpers.rb
@@ -151,7 +151,7 @@ More info at http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository}
         new_messages = @deployment["messages"] - printed_messages
         new_messages.each do |message|
           color = (message =~ /failed/) ? :red : :green
-          say message, color
+          say " ---> #{message}", color
           printed_messages << message
         end
 

--- a/spec/shelly/cli/main_spec.rb
+++ b/spec/shelly/cli/main_spec.rb
@@ -678,7 +678,7 @@ More info at http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository\e[0m
     context "single cloud in Cloudfile" do
       it "should start the cloud" do
         $stdout.should_receive(:puts).with(green "Starting cloud foo-production.")
-        $stdout.should_receive(:puts).with(green "message1")
+        $stdout.should_receive(:puts).with(green " ---> message1")
         $stdout.should_receive(:puts).with(green "Starting cloud successful")
         invoke(@main, :start)
       end
@@ -727,7 +727,7 @@ More info at http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository\e[0m
         @client.should_receive(:deployment).
           with("foo-staging", "DEPLOYMENT_ID").and_return(@deployment)
         $stdout.should_receive(:puts).with(green "Starting cloud foo-staging.")
-        $stdout.should_receive(:puts).with(green "message1")
+        $stdout.should_receive(:puts).with(green " ---> message1")
         $stdout.should_receive(:puts).with(green "Starting cloud successful")
         @main.options = {:cloud => "foo-staging"}
         invoke(@main, :start)
@@ -835,7 +835,7 @@ Wait until cloud is in 'turned off' state and try again.")
     it "should stop the cloud" do
       $stdout.should_receive(:print).with("Are you sure you want to shut down 'foo-production' cloud (yes/no): ")
       $stdout.should_receive(:puts).with("\n")
-      $stdout.should_receive(:puts).with(green "message1")
+      $stdout.should_receive(:puts).with(green " ---> message1")
       $stdout.should_receive(:puts).with(green "Stopping cloud successful")
       fake_stdin(["yes"]) do
         invoke(@main, :stop)
@@ -848,7 +848,7 @@ Wait until cloud is in 'turned off' state and try again.")
           @app.stub(:deployment => {"messages" => ["message1"],
             "result" => "failure", "state" => "deploy_failed"})
 
-          $stdout.should_receive(:puts).with(green "message1")
+          $stdout.should_receive(:puts).with(green " ---> message1")
           $stdout.should_receive(:puts).
             with(red "Stopping cloud failed. See logs with `shelly deploy show last --cloud foo-production`")
           fake_stdin(["yes"]) do
@@ -1280,7 +1280,7 @@ Wait until cloud is in 'turned off' state and try again.")
     end
 
     it "should print deployment messages" do
-      $stdout.should_receive(:puts).with(green "message1")
+      $stdout.should_receive(:puts).with(green " ---> message1")
       $stdout.should_receive(:puts).with(green "Cloud redeploy successful")
       invoke(@main, :redeploy)
     end
@@ -1290,7 +1290,7 @@ Wait until cloud is in 'turned off' state and try again.")
         it "should display error and `shelly deploy show last --cloud foo-production` command" do
           @app.stub(:deployment => {"messages" => ["message1"],
             "result" => "failure", "state" => "deploy_failed"})
-          $stdout.should_receive(:puts).with(green "message1")
+          $stdout.should_receive(:puts).with(green " ---> message1")
           $stdout.should_receive(:puts).
             with(red "Cloud redeploy failed. See logs with `shelly deploy show last --cloud foo-production`")
           invoke(@main, :redeploy)


### PR DESCRIPTION
for more consistent output with deployment progress.

![output-push](https://f.cloud.github.com/assets/619324/721474/dba13988-dfe3-11e2-9397-88e13d708a30.png)
![output-start-stop](https://f.cloud.github.com/assets/619324/721475/de089504-dfe3-11e2-9f01-5cbf0186823a.png)
