### PR TITLE
Reflecting API changes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* [improvement] API changes to handle user virtual server interactions
+
 ## 0.3.1 / 2013-06-28
 
 * [feature] `shelly database reset` reset PostgreSQL or MongoDB database, also possible to use with `shelly backup import DB_KIND dump --reset` option

--- a/lib/shelly/cli/backup.rb
+++ b/lib/shelly/cli/backup.rb
@@ -132,7 +132,7 @@ module Shelly
         app.import_database(kind, archive, connection["server"])
         say "Database imported successfully", :green
       rescue Client::ConflictException => e
-        say_error e[:message]
+        say_error "Cloud #{app} wasn't deployed properly. Cannot import database."
       end
 
       no_tasks do

--- a/lib/shelly/cli/database.rb
+++ b/lib/shelly/cli/database.rb
@@ -20,6 +20,8 @@ module Shelly
         say "All database objects and data will be removed"
         ask_to_reset_database
         app.reset_database(kind)
+      rescue Client::ConflictException
+        say_error "Cloud #{app} wasn't deployed properly. Cannot reset database."
       end
     end
   end

--- a/lib/shelly/cli/file.rb
+++ b/lib/shelly/cli/file.rb
@@ -15,7 +15,7 @@ module Shelly
         app = multiple_clouds(options[:cloud], "file list #{path}")
         app.list_files(path)
       rescue Client::ConflictException
-        say_error "Cloud #{app} is not running. Cannot list files."
+        say_error "Cloud #{app} wasn't deployed properly. Cannot list files."
       end
 
       desc "upload PATH", "Upload files to persistent data storage"
@@ -23,7 +23,7 @@ module Shelly
         app = multiple_clouds(options[:cloud], "file upload #{path}")
         app.upload(path)
       rescue Client::ConflictException
-        say_error "Cloud #{app} is not running. Cannot upload files."
+        say_error "Cloud #{app} wasn't deployed properly. Cannot upload files."
       end
 
       desc "download [SOURCE_PATH] [DEST_PATH]", "Download files from persistent data storage"
@@ -36,7 +36,7 @@ module Shelly
         app = multiple_clouds(options[:cloud], "file download #{relative_source} #{destination}")
         app.download(relative_source, destination)
       rescue Client::ConflictException
-        say_error "Cloud #{app} is not running. Cannot download files."
+        say_error "Cloud #{app} wasn't deployed properly. Cannot download files."
       end
 
       method_option :force, :type => :boolean, :aliases => "-f",
@@ -52,7 +52,7 @@ module Shelly
 
         app.delete_file(path)
       rescue Client::ConflictException
-        say_error "Cloud #{app} is not running. Cannot delete files."
+        say_error "Cloud #{app} wasn't deployed properly. Cannot delete files."
       end
 
       no_tasks do

--- a/lib/shelly/client/apps.rb
+++ b/lib/shelly/client/apps.rb
@@ -38,10 +38,6 @@ class Shelly::Client
     get("/apps/#{code_name}/console", {:server => server})
   end
 
-  def configured_server(code_name)
-    get("/apps/#{code_name}/configured_server")
-  end
-
   def configured_db_server(code_name, server = nil)
     get("/apps/#{code_name}/configured_db_server", {:server => server})
   end

--- a/spec/shelly/app_spec.rb
+++ b/spec/shelly/app_spec.rb
@@ -348,15 +348,14 @@ describe Shelly::App do
 
   describe "#list_files" do
     it "should list files for given subpath in disk" do
-      @app.should_receive(:ssh).with(:command => "ls -l /home/foo-staging/disk/foo",
-        :type => :server)
+      @app.should_receive(:ssh).with(:command => "ls -l /home/foo-staging/disk/foo")
       @app.list_files("foo")
     end
   end
 
   describe "#upload" do
     it "should run rsync with proper parameters" do
-      @client.stub(:configured_server).and_return(
+      @client.stub(:console).and_return(
         {"host" => "console.example.com", "port" => "40010", "user" => "foo"})
       @app.should_receive(:system).with("rsync -avz -e 'ssh -o StrictHostKeyChecking=no -p 40010 -l foo' --progress /path console.example.com:/home/foo-staging/disk")
       @app.upload("/path")
@@ -365,7 +364,7 @@ describe Shelly::App do
 
   describe "#download" do
     it "should run rsync with proper parameters" do
-      @client.stub(:configured_server).and_return(
+      @client.stub(:console).and_return(
         {"host" => "console.example.com", "port" => "40010", "user" => "foo"})
       @app.should_receive(:system).with("rsync -avz -e 'ssh -o StrictHostKeyChecking=no -p 40010 -l foo' --progress console.example.com:/home/foo-staging/disk/. /tmp")
       @app.download(".", "/tmp")

--- a/spec/shelly/cli/file_spec.rb
+++ b/spec/shelly/cli/file_spec.rb
@@ -28,8 +28,8 @@ describe Shelly::CLI::File do
 
     context "cloud is not running" do
       it "should display error" do
-        @client.stub(:configured_server).and_raise(Shelly::Client::ConflictException)
-        $stdout.should_receive(:puts).with(red "Cloud foo-production is not running. Cannot list files.")
+        @client.stub(:console).and_raise(Shelly::Client::ConflictException)
+        $stdout.should_receive(:puts).with(red "Cloud foo-production wasn't deployed properly. Cannot list files.")
         lambda {
           invoke(@cli_files, :list, "some/path")
         }.should raise_error(SystemExit)
@@ -59,8 +59,8 @@ describe Shelly::CLI::File do
 
     context "cloud is not running" do
       it "should display error" do
-        @client.stub(:configured_server).and_raise(Shelly::Client::ConflictException)
-        $stdout.should_receive(:puts).with(red "Cloud foo-production is not running. Cannot upload files.")
+        @client.stub(:console).and_raise(Shelly::Client::ConflictException)
+        $stdout.should_receive(:puts).with(red "Cloud foo-production wasn't deployed properly. Cannot upload files.")
         lambda {
           invoke(@cli_files, :upload, "some/path")
         }.should raise_error(SystemExit)
@@ -84,6 +84,16 @@ describe Shelly::CLI::File do
       @client.stub(:console).and_return(expected)
       @app.should_receive(:download).with("some/path", "/destination")
       invoke(@cli_files, :download, "some/path", "/destination")
+    end
+
+    context "cloud is not running" do
+      it "should display error" do
+        @client.stub(:console).and_raise(Shelly::Client::ConflictException)
+        $stdout.should_receive(:puts).with(red "Cloud foo-production wasn't deployed properly. Cannot download files.")
+        lambda {
+          invoke(@cli_files, :download, "some/path")
+        }.should raise_error(SystemExit)
+      end
     end
   end
 
@@ -127,6 +137,16 @@ describe Shelly::CLI::File do
           fake_stdin(["no"]) do
             invoke(@cli_files, :delete, "some/path")
           end
+        }.should raise_error(SystemExit)
+      end
+    end
+
+    context "cloud is not running" do
+      it "should display error" do
+        @app.stub(:delete_file).and_raise(Shelly::Client::ConflictException)
+        $stdout.should_receive(:puts).with(red "Cloud foo-production wasn't deployed properly. Cannot delete files.")
+        lambda {
+          fake_stdin(["yes"]) { invoke(@cli_files, :delete, "some/path") }
         }.should raise_error(SystemExit)
       end
     end


### PR DESCRIPTION
Console connection will return the best possible instance, running if present or at least configured. This will let users to run console/rake/dbconsole/files management when deploy failed.

Fixed some error messages.

[#52521477]
