### PR TITLE
Travis-ci should send notification on campfire.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ rvm:
   - jruby-18mode
   - jruby-19mode
 notifications:
-  email:
-    recipients:
-      - devs@shellycloud.com
+  email: false
+  campfire:
+    secure: 'ZSIx+w/r0QrOtpWu8EfmlypA9+pCRYSNU01Hv0ZvxOBu1EEp1Z/sDif0dCyyLrhv7lUOESdlcfmwVXUx93zEk2f+YMakG0NBnvMUhlkUhBLEsxDdPIgihhTirUIcWLrtPhtUbFA68/eXAP55wlz4Vcou5CHz8kk0+qmUX7QnqlI='


### PR DESCRIPTION
**E-mail notifications have been disabled** - I think that there is no need to keep them.

![cf-notification](https://f.cloud.github.com/assets/619324/781221/9cd67686-ea1b-11e2-98bd-52448614e1e8.PNG)
