### PR TITLE
Do not show `shelly deploys..` instruction for last internal deployment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* [bugfix] Do not show `shelly deploys show last` instruction for last failed internal deployment.
+
 ## 0.4.2 / 2013-08-29
 
 * [improvement] Use thor version without binaries

--- a/lib/shelly/app.rb
+++ b/lib/shelly/app.rb
@@ -251,6 +251,14 @@ module Shelly
       state == 'turned_off'
     end
 
+    def in_failed_state?
+      state == "deploy_failed" || state == "configuration_failed"
+    end
+
+    def in_admin_maintenance?
+      state_description.start_with? "admin maintenance"
+    end
+
     def to_s
       code_name
     end

--- a/lib/shelly/cli/main.rb
+++ b/lib/shelly/cli/main.rb
@@ -100,7 +100,7 @@ module Shelly
       desc "info", "Show basic information about cloud"
       def info
         app = multiple_clouds(options[:cloud], "info")
-        msg = if app.state == "deploy_failed" || app.state == "configuration_failed"
+        msg = if app.in_failed_state?
           " (deployment log: `shelly deploys show last -c #{app}`)"
         end
         say "Cloud #{app}:", msg.present? ? :red : :green

--- a/lib/shelly/helpers.rb
+++ b/lib/shelly/helpers.rb
@@ -191,8 +191,8 @@ More info at http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository}
 
     def apps_table(apps)
       apps.map do |app|
-        msg = if app.state == "deploy_failed" || app.state == "configuration_failed"
-          " (deployment log: `shelly deploys show last -c #{app.code_name}`)"
+        msg = if app.in_failed_state? && !app.in_admin_maintenance?
+          " (deployment log: `shelly deploys show last -c #{app}`)"
         end
         [app.code_name, "|  #{app.state_description}#{msg}"]
       end

--- a/spec/shelly/app_spec.rb
+++ b/spec/shelly/app_spec.rb
@@ -206,6 +206,52 @@ describe Shelly::App do
     end
   end
 
+  describe "#in_failed_state?" do
+    context "when application is in deploy_failed state" do
+      it "should return true" do
+        @client.should_receive(:app).
+          and_return({'state' => 'deploy_failed'})
+        @app.in_failed_state?.should be_true
+      end
+    end
+
+    context "when application is in configuration_failed state" do
+      it "should return true" do
+        @client.should_receive(:app).
+          and_return({'state' => 'configuration_failed'})
+        @app.in_failed_state?.should be_true
+      end
+    end
+
+    %w(no_billing no_code turned_off turning_off deploying running).each do |state|
+      context "when application is in #{state} state" do
+        it "should return false" do
+          @client.should_receive(:app).
+            and_return({'state' => state})
+          @app.in_failed_state?.should be_false
+        end
+      end
+    end
+  end
+
+  describe "#in_admin_mainenance?" do
+    context "when application state description starts with admin maintenance" do
+      it "should return true" do
+        @client.should_receive(:app).
+          and_return({'state_description' => 'admin maintenance running'})
+        @app.in_admin_maintenance?.should be_true
+      end
+    end
+
+    context "when application state description does not start with admin maintenance" do
+      it "should return false" do
+        @client.should_receive(:app).
+          and_return({'state_description' => 'turned off'})
+        @app.in_admin_maintenance?.should be_false
+      end
+    end
+  end
+
   describe "#deploy_logs" do
     it "should list deploy_logs" do
       @client.should_receive(:deploy_logs).with("foo-staging")


### PR DESCRIPTION
![zrzut ekranu z 2013-08-29 21 45 23](https://f.cloud.github.com/assets/619324/1052822/d89e8f8e-10e3-11e3-8066-04dd2c1a58c2.png)

We could also implement it through the api (add info if last deployment was internal), but I think that it is pointless in this case. This solution is sufficient. What do You think?
