### PR TITLE
Print user-friendly message for bad .netrc permission.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* [improvement] Print user-friendly message for bad .netrc file permission.
+
 ## 0.4.4 / 2013-09-10
 
 * [bugfix] Do not show `shelly deploys show last` instruction if last deployment was made by admin and was failed.

--- a/lib/shelly/cli/runner.rb
+++ b/lib/shelly/cli/runner.rb
@@ -34,6 +34,9 @@ module Shelly
         raise if debug?
         say_new_line
         say_error "[canceled]"
+      rescue Netrc::Error => e
+        raise if debug?
+        say_error e.message
       rescue Client::APIException => e
         raise if debug?
         say_error "You have found a bug in the shelly gem. We're sorry.",

--- a/spec/shelly/cli/runner_spec.rb
+++ b/spec/shelly/cli/runner_spec.rb
@@ -107,6 +107,13 @@ describe Shelly::CLI::Runner do
         }.should raise_error(RuntimeError)
       end
 
+      it "should re-raise netrc exception" do
+        Shelly::CLI::Main.stub(:start).and_raise(Netrc::Error.new)
+        lambda {
+          @runner.start
+        }.should raise_error(Netrc::Error)
+      end
+
       it "should re-raise unauthorized exception" do
         Shelly::CLI::Main.stub(:start).and_raise(Shelly::Client::UnauthorizedException.new)
         lambda {
@@ -134,6 +141,15 @@ describe Shelly::CLI::Runner do
         Shelly::CLI::Main.stub(:start).and_raise(RuntimeError.new)
         runner = Shelly::CLI::Runner.new(%w(version))
         $stdout.should_receive(:puts).with("Unknown error, to see debug information run command with --debug")
+        lambda {
+          runner.start
+        }.should raise_error(SystemExit)
+      end
+
+      it "should rescue netrc exception and display message" do
+        Shelly::CLI::Main.stub(:start).and_raise(Netrc::Error.new("Error"))
+        runner = Shelly::CLI::Runner.new(%w(start))
+        $stdout.should_receive(:puts).with("Error")
         lambda {
           runner.start
         }.should raise_error(SystemExit)


### PR DESCRIPTION
![zaznaczenie_001](https://f.cloud.github.com/assets/619324/1194803/864d4844-248c-11e3-8f3f-d7cbc71b7f81.png)
