### PR TITLE
Added handling for Client::NotFoundException in file cli.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## master
+
+* [bugfix] Print user-friendly message if user tries to operate on files
+  on cloud which is not deployed.
+
 # 0.4.11 / 2013-10-30
 
 * internal changes

--- a/lib/shelly/cli/file.rb
+++ b/lib/shelly/cli/file.rb
@@ -14,6 +14,8 @@ module Shelly
       def list(path = "/")
         app = multiple_clouds(options[:cloud], "file list #{path}")
         app.list_files(path)
+      rescue Client::NotFoundException => e
+        say_error e["message"]
       rescue Client::ConflictException
         say_error "Cloud #{app} wasn't deployed properly. Cannot list files."
       end
@@ -22,6 +24,8 @@ module Shelly
       def upload(path)
         app = multiple_clouds(options[:cloud], "file upload #{path}")
         app.upload(path)
+      rescue Client::NotFoundException => e
+        say_error e["message"]
       rescue Client::ConflictException
         say_error "Cloud #{app} wasn't deployed properly. Cannot upload files."
       end
@@ -35,6 +39,8 @@ module Shelly
       def download(relative_source = ".", destination = ".")
         app = multiple_clouds(options[:cloud], "file download #{relative_source} #{destination}")
         app.download(relative_source, destination)
+      rescue Client::NotFoundException => e
+        say_error e["message"]
       rescue Client::ConflictException
         say_error "Cloud #{app} wasn't deployed properly. Cannot download files."
       end
@@ -51,6 +57,8 @@ module Shelly
         end
 
         app.delete_file(path)
+      rescue Client::NotFoundException => e
+        say_error e["message"]
       rescue Client::ConflictException
         say_error "Cloud #{app} wasn't deployed properly. Cannot delete files."
       end

--- a/spec/shelly/cli/file_spec.rb
+++ b/spec/shelly/cli/file_spec.rb
@@ -37,6 +37,19 @@ describe Shelly::CLI::File do
       end
     end
 
+    context "when cloud is not deployed" do
+      it "should display error" do
+        @app.stub(:attributes => {"system_user" => "system_user"})
+        exception = Shelly::Client::NotFoundException.
+          new({"message" => "Virtual server not found or not configured"})
+        @client.stub(:tunnel).and_raise(exception)
+        $stdout.should_receive(:puts).
+          with(red "Virtual server not found or not configured")
+        lambda {
+          invoke(@cli_files, :list, "some/path")
+        }.should raise_error(SystemExit)
+      end
+    end
   end
 
   describe "#upload" do
@@ -67,6 +80,19 @@ describe Shelly::CLI::File do
         }.should raise_error(SystemExit)
       end
     end
+
+    context "when cloud is not deployed" do
+      it "should display error" do
+        exception = Shelly::Client::NotFoundException.
+          new({"message" => "Virtual server not found or not configured"})
+        @client.stub(:tunnel).and_raise(exception)
+        $stdout.should_receive(:puts).
+          with(red "Virtual server not found or not configured")
+        lambda {
+          invoke(@cli_files, :upload, "some/path")
+        }.should raise_error(SystemExit)
+      end
+    end
   end
 
   describe "#download" do
@@ -91,6 +117,19 @@ describe Shelly::CLI::File do
       it "should display error" do
         @client.stub(:tunnel).and_raise(Shelly::Client::ConflictException)
         $stdout.should_receive(:puts).with(red "Cloud foo-production wasn't deployed properly. Cannot download files.")
+        lambda {
+          invoke(@cli_files, :download, "some/path")
+        }.should raise_error(SystemExit)
+      end
+    end
+
+    context "when cloud is not deployed" do
+      it "should display error" do
+        exception = Shelly::Client::NotFoundException.
+          new({"message" => "Virtual server not found or not configured"})
+        @client.stub(:tunnel).and_raise(exception)
+        $stdout.should_receive(:puts).
+          with(red "Virtual server not found or not configured")
         lambda {
           invoke(@cli_files, :download, "some/path")
         }.should raise_error(SystemExit)
@@ -146,6 +185,19 @@ describe Shelly::CLI::File do
       it "should display error" do
         @app.stub(:delete_file).and_raise(Shelly::Client::ConflictException)
         $stdout.should_receive(:puts).with(red "Cloud foo-production wasn't deployed properly. Cannot delete files.")
+        lambda {
+          fake_stdin(["yes"]) { invoke(@cli_files, :delete, "some/path") }
+        }.should raise_error(SystemExit)
+      end
+    end
+
+    context "when cloud is not deployed" do
+      it "should display error" do
+        exception = Shelly::Client::NotFoundException.
+          new({"message" => "Virtual server not found or not configured"})
+        @app.stub(:delete_file).and_raise(exception)
+        $stdout.should_receive(:puts).
+          with(red "Virtual server not found or not configured")
         lambda {
           fake_stdin(["yes"]) { invoke(@cli_files, :delete, "some/path") }
         }.should raise_error(SystemExit)


### PR DESCRIPTION
Print user-friendly message if cloud is not deployed.

![terminal_001](https://f.cloud.github.com/assets/619324/1426690/488f86bc-4074-11e3-8f36-aeeae3e1ecfc.png)
