### PR TITLE
Cleaned up SSH keys handling

### DIFF
--- a/lib/shelly/cli/main.rb
+++ b/lib/shelly/cli/main.rb
@@ -58,12 +58,12 @@ module Shelly
       def login(email = nil)
         user = Shelly::User.new
         say "Your public SSH key will be uploaded to Shelly Cloud after login."
-        raise Errno::ENOENT, user.ssh_key_path unless user.ssh_key_exists?
+        raise Errno::ENOENT, user.ssh_key.path unless user.ssh_key.exists?
         email ||= ask_for_email
         password = ask_for_password(:with_confirmation => false)
         user.login(email, password)
-        say "Login successful", :green
         upload_ssh_key
+        say "Login successful", :green
         list
       rescue Client::ValidationException => e
         e.each_error { |error| say_error "#{error}", :with_exit => false }
@@ -248,7 +248,7 @@ Wait until cloud is in 'turned off' state and try again.}
       desc "logout", "Logout from Shelly Cloud"
       def logout
         user = Shelly::User.new
-        say "Your public SSH key has been removed from Shelly Cloud" if user.delete_ssh_key
+        say "Your public SSH key has been removed from Shelly Cloud" if user.ssh_keys.destroy
         say "You have been successfully logged out" if user.logout
       end
 
@@ -456,15 +456,21 @@ Wait until cloud is in 'turned off' state and try again.}
 
         def upload_ssh_key
           user = Shelly::User.new
-          if user.ssh_key_exists?
-            say "Uploading your public SSH key from #{user.ssh_key_path}"
-            user.upload_ssh_key
+          if user.ssh_key.exists?
+            if user.ssh_key.uploaded?
+              say "Your SSH key from #{user.ssh_key.path} is already uploaded"
+            else
+              say "Uploading your public SSH key from #{user.ssh_key.path}"
+              user.ssh_key.upload
+            end
           else
             say_error "No such file or directory - #{user.ssh_key_path}", :with_exit => false
             say_error "Use ssh-keygen to generate ssh key pair, after that use: `shelly login`", :with_exit => false
           end
         rescue Client::ValidationException => e
           e.each_error { |error| say_error error, :with_exit => false }
+          user.logout
+          exit 1
         end
       end
     end

--- a/lib/shelly/cli/user.rb
+++ b/lib/shelly/cli/user.rb
@@ -1,5 +1,6 @@
 require "shelly/cli/command"
 require "shelly/cli/organization"
+require "shelly/ssh_keys"
 
 module Shelly
   module CLI

--- a/lib/shelly/client/ssh_keys.rb
+++ b/lib/shelly/client/ssh_keys.rb
@@ -3,7 +3,11 @@ class Shelly::Client
     post("/ssh_keys", :ssh_key => ssh_key)
   end
 
-  def delete_ssh_key(ssh_key)
-    delete("/ssh_keys", :ssh_key => ssh_key)
+  def delete_ssh_key(fingerprint)
+    delete("/ssh_keys/#{fingerprint}")
+  end
+
+  def ssh_key(fingerprint)
+    get("/ssh_keys/#{fingerprint}")
   end
 end

--- a/lib/shelly/ssh_key.rb
+++ b/lib/shelly/ssh_key.rb
@@ -1,0 +1,36 @@
+module Shelly
+  class SshKey < Model
+    attr_reader :path
+    def initialize(path)
+      @path = File.expand_path(path)
+    end
+
+    def exists?
+      File.exists?(path)
+    end
+
+    def destroy
+      shelly.delete_ssh_key(fingerprint) if exists?
+    end
+
+    def upload
+      shelly.add_ssh_key(key)
+    end
+
+    def uploaded?
+      return false unless exists?
+      shelly.ssh_key(fingerprint)
+      true
+    rescue Shelly::Client::NotFoundException
+      false
+    end
+
+    def fingerprint
+      `ssh-keygen -lf #{path}`.split(" ")[1]
+    end
+
+    def key
+      File.read(path)
+    end
+  end
+end

--- a/lib/shelly/ssh_keys.rb
+++ b/lib/shelly/ssh_keys.rb
@@ -1,0 +1,18 @@
+require "shelly/ssh_key"
+
+module Shelly
+  class SshKeys
+    def initialize
+      @rsa = SshKey.new('~/.ssh/id_rsa.pub')
+      @dsa = SshKey.new('~/.ssh/id_dsa.pub')
+    end
+
+    def destroy
+      [@rsa, @dsa].map(&:destroy).any?
+    end
+
+    def prefered_key
+      @dsa.exists? ? @dsa : @rsa
+    end
+  end
+end

--- a/lib/shelly/user.rb
+++ b/lib/shelly/user.rb
@@ -43,30 +43,16 @@ module Shelly
       shelly.forget_authorization
     end
 
+    def ssh_keys
+      @keys ||= SshKeys.new
+    end
+
+    def ssh_key
+      ssh_keys.prefered_key
+    end
+
     def delete_credentials
       File.delete(credentials_path) if credentials_exists?
-    end
-
-    def delete_ssh_key
-      shelly.delete_ssh_key(File.read(dsa_key)) if File.exists?(dsa_key)
-      shelly.delete_ssh_key(File.read(rsa_key)) if File.exists?(rsa_key)
-    end
-
-    def ssh_key_exists?
-      File.exists?(ssh_key_path)
-    end
-
-    def ssh_key_path
-      return dsa_key if File.exists?(dsa_key)
-      rsa_key
-    end
-
-    def dsa_key
-      File.expand_path("~/.ssh/id_dsa.pub")
-    end
-
-    def rsa_key
-      File.expand_path("~/.ssh/id_rsa.pub")
     end
 
     def self.guess_email
@@ -75,11 +61,6 @@ module Shelly
 
     def config_dir
       File.expand_path("~/.shelly")
-    end
-
-    def upload_ssh_key
-      key = File.read(ssh_key_path).strip
-      shelly.add_ssh_key(key)
     end
 
     protected

--- a/spec/shelly/client_spec.rb
+++ b/spec/shelly/client_spec.rb
@@ -286,8 +286,8 @@ describe Shelly::Client do
 
   describe "#delete_ssh_key" do
     it "should send delete with given SSH key" do
-      @client.should_receive(:delete).with("/ssh_keys", {:ssh_key => "abc"})
-      @client.delete_ssh_key("abc")
+      @client.should_receive(:delete).with("/ssh_keys/f6:08:b8:46:df:6d:b2:86:48:ae:e5:7c:25:ef:cf:ad")
+      @client.delete_ssh_key("f6:08:b8:46:df:6d:b2:86:48:ae:e5:7c:25:ef:cf:ad")
     end
   end
 

--- a/spec/shelly/ssh_key_spec.rb
+++ b/spec/shelly/ssh_key_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require "shelly/ssh_key"
+
+describe Shelly::SshKey do
+  let(:ssh_key) { Shelly::SshKey.new("~/.ssh/id_rsa.pub") }
+  let(:fingerprint) { "f6:08:b8:46:df:6d:b2:86:48:ae:e5:7c:25:ef:cf:ad" }
+  before do
+    ssh_key.stub(:fingerprint => fingerprint)
+    FileUtils.mkdir_p("~/.ssh")
+    File.open(ssh_key.path, "w") { |f| f << "ssh-rsa AAAAB3NzaC1" }
+    @client = mock
+    Shelly::Client.stub(:new).and_return(@client)
+  end
+
+  describe "#destroy?" do
+    it "should destroy key via API" do
+      @client.should_receive(:delete_ssh_key).with(fingerprint)
+      ssh_key.destroy
+    end
+    context "key doesn't exist" do
+      it "should not try to destroy it" do
+        FileUtils.rm_rf(ssh_key.path)
+        @client.should_not_receive(:delete_ssh_key)
+        ssh_key.destroy
+      end
+    end
+  end
+
+  describe "#uploaded?" do
+    context "key exists for this user on Shelly" do
+      it "should return true" do
+        @client.stub(:ssh_key => {})
+        ssh_key.should be_uploaded
+      end
+    end
+
+    context "key doesn't exist on Shelly" do
+      it "should return true if key exists in Shelly" do
+        ex = Shelly::Client::NotFoundException.new
+        @client.stub(:ssh_key).and_raise(ex)
+        ssh_key.should_not be_uploaded
+      end
+    end
+  end
+end

--- a/spec/shelly/ssh_keys_spec.rb
+++ b/spec/shelly/ssh_keys_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "shelly/ssh_keys"
+
+describe Shelly::SshKeys do
+  let(:keys) { Shelly::SshKeys.new }
+  before { FileUtils.mkdir_p('~/.ssh') }
+  describe "#prefered_key" do
+    context "dsa key exists" do
+      before { FileUtils.touch("~/.ssh/id_dsa.pub") }
+      it "should return dsa key" do
+        keys.prefered_key.path.should match(/dsa/)
+      end
+    end
+    context "dsa key doesn't exists" do
+      it "should return rsa key" do
+        keys.prefered_key.path.should match(/rsa/)
+      end
+    end
+  end
+end

--- a/spec/shelly/user_spec.rb
+++ b/spec/shelly/user_spec.rb
@@ -5,9 +5,6 @@ describe Shelly::User do
   let(:password) { "secret" }
 
   before do
-    FileUtils.mkdir_p("~/.ssh")
-    File.open("~/.ssh/id_rsa.pub", "w") { |f| f << "rsa-key AAbbcc" }
-    File.open("~/.ssh/id_dsa.pub", "w") { |f| f << "dsa-key AAbbcc" }
     @client = mock
     Shelly::Client.stub(:new).and_return(@client)
     @user = Shelly::User.new
@@ -39,49 +36,6 @@ describe Shelly::User do
       File.open("~/.shelly/credentials", "w") { |f| f << "bob@example.com\nsecret" }
       @user.delete_credentials
       File.exists?("~/.shelly/credentials").should be_false
-    end
-  end
-
-  describe "#ssh_key_path" do
-    it "should return path to public dsa key file in the first place" do
-      @user.ssh_key_path.should == File.expand_path("~/.ssh/id_dsa.pub")
-    end
-
-    it "should return path to public rsa key file if dsa key is not present" do
-      FileUtils.rm_rf("~/.ssh/id_dsa.pub")
-      @user.ssh_key_path.should == File.expand_path("~/.ssh/id_rsa.pub")
-    end
-  end
-
-  describe "#ssh_key_exists?" do
-    it "should return true if key exists, false otherwise" do
-      @user.should be_ssh_key_exists
-      FileUtils.rm_rf("~/.ssh/id_rsa.pub")
-      @user.should be_ssh_key_exists
-      FileUtils.rm_rf("~/.ssh/id_dsa.pub")
-      @user.should_not be_ssh_key_exists
-    end
-  end
-
-  describe "#delete_ssh_key" do
-    it "should invoke logout when ssh key exists" do
-      @client.should_receive(:delete_ssh_key).with('rsa-key AAbbcc').and_return(true)
-      @client.should_receive(:delete_ssh_key).with('dsa-key AAbbcc').and_return(true)
-      @user.delete_ssh_key.should be_true
-    end
-
-    it "should not invoke logout when ssh key doesn't exist" do
-      FileUtils.rm_rf("~/.ssh/id_rsa.pub")
-      FileUtils.rm_rf("~/.ssh/id_dsa.pub")
-      @client.should_not_receive(:logout)
-      @user.delete_ssh_key.should be_false
-    end
-  end
-
-  describe "#upload_ssh_key" do
-    it "should read and upload user's public SSH key" do
-      @client.should_receive(:add_ssh_key).with("dsa-key AAbbcc")
-      @user.upload_ssh_key
     end
   end
 


### PR DESCRIPTION
- SSH keys are identified by fingerprint not by key itself. This fixes possible problems with deleting ssh keys.
- Don't upload SSH key if it's already uploaded
