### PR TITLE
Remove SshKey only if it was uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* [bugfix] Remove ssh_key from Shelly Cloud only if it was already uploaded
+
 ## 0.4.16 / 2013-11-26
 
 * [improvement] Validate kind when importing database backup

--- a/lib/shelly/ssh_key.rb
+++ b/lib/shelly/ssh_key.rb
@@ -10,7 +10,7 @@ module Shelly
     end
 
     def destroy
-      shelly.delete_ssh_key(fingerprint) if exists?
+      shelly.delete_ssh_key(fingerprint) if uploaded?
     end
 
     def upload

--- a/spec/shelly/ssh_key_spec.rb
+++ b/spec/shelly/ssh_key_spec.rb
@@ -13,13 +13,24 @@ describe Shelly::SshKey do
   end
 
   describe "#destroy?" do
-    it "should destroy key via API" do
+    it "should destroy key via API if it's uploaded" do
+      @client.should_receive(:ssh_key).with(fingerprint).and_return(true)
       @client.should_receive(:delete_ssh_key).with(fingerprint)
       ssh_key.destroy
     end
+
     context "key doesn't exist" do
       it "should not try to destroy it" do
         FileUtils.rm_rf(ssh_key.path)
+        @client.should_not_receive(:delete_ssh_key)
+        ssh_key.destroy
+      end
+    end
+
+    context "key isn't uploaded" do
+      it "should not try to destroy it" do
+        @client.should_receive(:ssh_key).with(fingerprint).
+          and_raise(Shelly::Client::NotFoundException.new)
         @client.should_not_receive(:delete_ssh_key)
         ssh_key.destroy
       end


### PR DESCRIPTION
When user has two keys RSA and DSA, both exist but only one is uploaded.

[#61536676]
