### PR TITLE
Gemfile ruby version specified - added to shelly check and generated Cloudfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## master
 
 * [bugfix] `shelly delete` fixed remove git remote when deleting cloud
+* [improvement] `shelly check` makes sure Ruby defined in Gemfile is supported
+* [improvement] use Ruby defined in Gemfile to create Cloudfile
 * [bugfix] shelly cert arguments inline help reorderd
 
 ## 0.4.18 / 2013-12-17

--- a/lib/shelly/app.rb
+++ b/lib/shelly/app.rb
@@ -400,8 +400,26 @@ module Shelly
     def assign_attributes(response)
       self.git_url = response["git_url"]
       self.domains = response["domains"]
-      self.ruby_version = jruby? ? 'jruby' : response["ruby_version"]
+      self.ruby_version = detect_ruby_version || response["ruby_version"]
       self.environment = response["environment"]
+    end
+
+    def detect_ruby_version
+      jruby? ? 'jruby' : gemfile_ruby_version
+    end
+
+    def gemfile_ruby_version
+      ruby_version = Bundler::Definition.build("Gemfile", "Gemfile.lock",
+        nil).ruby_version
+      return unless ruby_version
+
+      if ruby_version.engine == 'jruby'
+        'jruby'
+      elsif ruby_version.version == '1.8.7'
+        'ree-1.8.7'
+      else
+        ruby_version.version
+      end
     end
 
     def persistent_disk

--- a/lib/shelly/app.rb
+++ b/lib/shelly/app.rb
@@ -415,8 +415,6 @@ module Shelly
 
       if ruby_version.engine == 'jruby'
         'jruby'
-      elsif ruby_version.version == '1.8.7'
-        'ree-1.8.7'
       else
         ruby_version.version
       end

--- a/lib/shelly/cli/main/check.rb
+++ b/lib/shelly/cli/main/check.rb
@@ -27,6 +27,37 @@ module Shelly
           "Gemfile.lock is missing in git repository",
           :show_fulfilled => verbose)
 
+        if structure.gemfile_ruby_version?
+          if structure.gemfile_engine == 'ruby'
+            print_check(!['1.8.7', '2.1.0'].include?(structure.gemfile_ruby_version),
+              "#{structure.gemfile_engine} #{structure.gemfile_ruby_version} is supported",
+              "#{structure.gemfile_engine} #{structure.gemfile_ruby_version} is currently unsupported\n    See more at https://shellycloud.com/documentation/requirements#ruby_versions",
+              :show_fulfilled => verbose)
+          end
+
+          if structure.gemfile_ruby_patchlevel
+            print_check(false, "",
+              "Remove Ruby patchlevel from Gemfile\n    Shelly Cloud takes care of upgrading Rubies whenever they are released\n    See more at https://shellycloud.com/documentation/requirements#ruby_versions",
+              :show_fulfilled => verbose)
+          end
+
+          supported_jruby = '1.7.8'
+          if structure.gemfile_engine == 'jruby'
+            print_check(!(structure.gemfile_ruby_version == '1.8.7' ||
+                structure.gemfile_engine_version != supported_jruby),
+              "jruby #{supported_jruby} (1.9 mode) is supported",
+              "Only jruby #{supported_jruby} (1.9 mode) is currently supported\n    See more at https://shellycloud.com/documentation/requirements#ruby_versions",
+              :show_fulfilled => verbose)
+          end
+
+          # other platforms: rbx, mingw, mswin show instant error
+          unless ['jruby', 'ruby'].include?(structure.gemfile_engine)
+            print_check(false, "",
+              "Your ruby engine: #{structure.gemfile_engine} is currently unsupported\n    See more at https://shellycloud.com/documentation/requirements#ruby_versions",
+              :show_fulfilled => verbose)
+          end
+        end
+
         print_check(structure.config_ru?, "config.ru is present",
           "config.ru is missing",
           :show_fulfilled => verbose)
@@ -93,14 +124,14 @@ module Shelly
 
             if app.thin?
               print_check(structure.gem?("thin"),
-                "Web server gem 'thin' is present",
+                "Web server gem 'thin' is present for '#{app}' cloud",
                 "Gem 'thin' is missing in the Gemfile for '#{app}' cloud",
                 :show_fulfilled => verbose)
             end
 
             if app.puma?
               print_check(structure.gem?("puma"),
-                "Web server gem 'puma' is present",
+                "Web server gem 'puma' is present for '#{app}' cloud",
                 "Gem 'puma' is missing in the Gemfile for '#{app}' cloud",
                 :show_fulfilled => verbose)
             end

--- a/lib/shelly/structure_validator.rb
+++ b/lib/shelly/structure_validator.rb
@@ -15,6 +15,30 @@ module Shelly
       repo_paths.include?(@gemfile_lock_path)
     end
 
+    def gemfile_ruby_version?
+      return false unless gemfile? && gemfile_lock?
+      definition.ruby_version
+    end
+
+    def gemfile_ruby_version
+      definition.ruby_version.version
+    end
+
+    # patchlevel is supported since bundler 1.4.0.rc
+    def gemfile_ruby_patchlevel
+      if definition.ruby_version.respond_to?(:patchlevel)
+        definition.ruby_version.patchlevel
+      end
+    end
+
+    def gemfile_engine
+      definition.ruby_version.engine
+    end
+
+    def gemfile_engine_version
+      definition.ruby_version.engine_version
+    end
+
     def config_ru?
       repo_paths.include?("config.ru")
     end
@@ -53,9 +77,12 @@ module Shelly
 
     def gems
       return [] unless gemfile? && gemfile_lock?
-      definition = Bundler::Definition.build(@gemfile_path,
-        @gemfile_lock_path, nil)
       @gems ||= definition.specs.map(&:name)
+    end
+
+    def definition
+      @definition ||= Bundler::Definition.build(@gemfile_path,
+        @gemfile_lock_path, nil)
     end
 
     def tasks

--- a/spec/shelly/app_spec.rb
+++ b/spec/shelly/app_spec.rb
@@ -373,14 +373,6 @@ describe Shelly::App do
         @app.ruby_version.should == 'jruby'
       end
 
-      it "should return ree-1.8.7 if ruby version is set to 1.8.7" do
-        Bundler::Definition.stub_chain(:build, :ruby_version).
-          and_return(mock(:engine => 'ruby', :version => '1.8.7'))
-
-        @app.create
-        @app.ruby_version.should == 'ree-1.8.7'
-      end
-
       it "should return ruby_version from gemfile" do
         Bundler::Definition.stub_chain(:build, :ruby_version).
           and_return(mock(:engine => 'ruby', :version => '1.9.3'))

--- a/spec/shelly/app_spec.rb
+++ b/spec/shelly/app_spec.rb
@@ -325,8 +325,11 @@ describe Shelly::App do
   end
 
   describe "#create" do
+    before { @app.stub(:gemfile_ruby_version) }
+
     it "should create the app on shelly cloud via API client" do
       @app.code_name = "fooo"
+
       attributes = {
         :code_name => "fooo",
         :organization_name => nil,
@@ -348,12 +351,43 @@ describe Shelly::App do
       @app.environment.should == "production"
     end
 
-    it "should assign jruby as ruby_version if gem is running under jruby" do
-      @client.stub(:create_app).and_return("git_url" => nil,
-        "domains" => nil, "environment" => nil, "ruby_version" => "1.9.2")
-      stub_const('RUBY_PLATFORM', 'java')
-      @app.create
-      @app.ruby_version.should == "jruby"
+    context "ruby version" do
+      before do
+        @app.unstub(:gemfile_ruby_version)
+        stub_const('RUBY_PLATFORM', 'i686-linux')
+        @client.stub(:create_app).and_return("git_url" => "git@git.example.com:fooo.git",
+          "domains" => ["fooo.shellyapp.com"], "ruby_version" => "1.9.2", "environment" => "production")
+      end
+
+      it "should assign jruby as ruby_version if gem is running under jruby" do
+        stub_const('RUBY_PLATFORM', 'java')
+        @app.create
+        @app.ruby_version.should == "jruby"
+      end
+
+      it "should return jruby if engine is set to jruby" do
+        Bundler::Definition.stub_chain(:build, :ruby_version).
+          and_return(mock(:engine => 'jruby'))
+
+        @app.create
+        @app.ruby_version.should == 'jruby'
+      end
+
+      it "should return ree-1.8.7 if ruby version is set to 1.8.7" do
+        Bundler::Definition.stub_chain(:build, :ruby_version).
+          and_return(mock(:engine => 'ruby', :version => '1.8.7'))
+
+        @app.create
+        @app.ruby_version.should == 'ree-1.8.7'
+      end
+
+      it "should return ruby_version from gemfile" do
+        Bundler::Definition.stub_chain(:build, :ruby_version).
+          and_return(mock(:engine => 'ruby', :version => '1.9.3'))
+
+        @app.create
+        @app.ruby_version.should == "1.9.3"
+      end
     end
   end
 


### PR DESCRIPTION
```
$ shelly_local check
Checking Shelly Cloud requirements

  ✓ Gemfile is present
  ✓ Gemfile.lock is present
  ✓ jruby 1.7.4 (1.9 mode) is supported
```

```
$ shelly_local check
Checking Shelly Cloud requirements

  ✓ Gemfile is present
  ✓ Gemfile.lock is present
  ✗ Only jruby 1.7.4 (1.9 mode) is currently supported
    See more at https://shellycloud.com/documentation/requirements#ruby_versions
```

```
$ shelly_local check
Checking Shelly Cloud requirements

  ✓ Gemfile is present
  ✓ Gemfile.lock is present
  ✗ Your ruby engine: rbx is currently unsupported
    See more at https://shellycloud.com/documentation/requirements#ruby_versions
```

```
$ shelly_local check
Checking Shelly Cloud requirements

  ✓ Gemfile is present
  ✓ Gemfile.lock is present
  ✗ ruby 2.1.0 is currently unsupported
    See more at https://shellycloud.com/documentation/requirements#ruby_versions
```
