### PR TITLE
`shelly config create' should check if config already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * [feature] `shelly config create` will check if config already exists in
   specified path
+* [bugfix] With multiple clouds in `Cloudfile`, `shelly config create`
+  should not open the editor if no cloud is specified
 
 ## 0.4.29 / 2014-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master
+
+* [feature] `shelly config create` will check if config already exists in
+  specified path
+
 ## 0.4.29 / 2014-03-27
 
 * [bugfix] Use childprocess to start ssh related commands. Fixes tty issue

--- a/lib/shelly/cli/config.rb
+++ b/lib/shelly/cli/config.rb
@@ -50,11 +50,15 @@ module Shelly
       map "new" => :create
       desc "create PATH", "Create configuration file"
       def create(path)
-        output = open_editor(path)
         app = multiple_clouds(options[:cloud], "create #{path}")
-        app.create_config(path, output)
-        say "File '#{path}' created.", :green
-        next_action_info(app)
+        if app.config_exists?(path)
+          say "File '#{path}' already exists. Use `shelly config edit #{path} --cloud #{options[:cloud]}` to update it.", :red
+        else
+          output = open_editor(path)
+          app.create_config(path, output)
+          say "File '#{path}' created.", :green
+          next_action_info(app)
+        end
       rescue Client::ValidationException => e
         e.each_error { |error| say_error error, :with_exit => false }
         exit 1

--- a/spec/shelly/cli/config_spec.rb
+++ b/spec/shelly/cli/config_spec.rb
@@ -126,6 +126,20 @@ describe Shelly::CLI::Config do
       invoke(@config, :create, "new_config")
     end
 
+    context "when multiple clouds in Cloudfile" do
+      before do
+        File.open("Cloudfile", 'w') {|f|
+          f.write("foo-staging:\nfoo-production:\n") }
+      end
+
+      it "should not open the editor if no cloud is specified" do
+        @config.unstub(:multiple_clouds)
+        @config.should_not_receive(:system)
+        $stdout.should_receive(:puts).with(red "You have multiple clouds in Cloudfile.")
+        lambda { invoke(@config, :create, "path") }.should raise_error(SystemExit)
+      end
+    end
+
     it "should ask to set EDITOR environment variable if not set" do
       @config.stub(:system) {false}
       @app.stub(:config_exists? => false)


### PR DESCRIPTION
If it does, it will suggest using `shelly config update` and quit. Also fixes the bug where `shelly config create` would open the editor would when no cloud is specified.

[#68558140]
[#68557874]
