### PR TITLE
Updated mime-types dependency

### DIFF
--- a/shelly.gemspec
+++ b/shelly.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_runtime_dependency "wijet-thor", "~> 0.14.10"
   s.add_runtime_dependency "rest-client"
-  s.add_runtime_dependency "mime-types", "~> 1.16"
+  s.add_runtime_dependency "mime-types", ">= 1.16", "< 3.0"
   s.add_runtime_dependency "json"
   s.add_runtime_dependency "ruby-progressbar"
   s.add_runtime_dependency "launchy"


### PR DESCRIPTION
I have forced the tests to run with mime-types version 2.4.3 and it's all green.

Anything missing?
