### PR TITLE
Handle escaping before executing a task on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 
+* [improvement] shelly rake accepts rake arguments and properly escapes whitespaces
 * [bugfix] Display proper error for shelly files commands depending on resource
 
 ## 0.5.5 / 2015-03-16

--- a/lib/shelly/app.rb
+++ b/lib/shelly/app.rb
@@ -238,7 +238,7 @@ module Shelly
     end
 
     def rake(task, server = nil)
-      ssh(:command => "rake_runner \"#{task}\"", :server => server)
+      ssh(:command => "rake_runner '#{task.inspect}'", :server => server)
     end
 
     def dbconsole

--- a/spec/shelly/app_spec.rb
+++ b/spec/shelly/app_spec.rb
@@ -426,7 +426,7 @@ describe Shelly::App do
     it "should return result of rake task" do
       @client.stub(:tunnel).and_return(
         {"host" => "console.example.com", "port" => "40010", "user" => "foo"})
-      @app.should_receive(:childprocess).with("ssh -o StrictHostKeyChecking=no -p 40010 -l foo -t -t console.example.com rake_runner \"test\"")
+      @app.should_receive(:childprocess).with("ssh -o StrictHostKeyChecking=no -p 40010 -l foo -t -t console.example.com rake_runner '\"test\"'")
       @app.rake("test")
     end
 


### PR DESCRIPTION
Allows to run:

`shelly rake -vT db`
`shelly rake 'environment tire:import CLASS="Post"'`
`shelly rake my_task[1,"1 2"]`

This patch requires updating `rake_runner` on virtual servers https://github.com/shellycloud/winnie-chef/pull/466

[#99887000]
